### PR TITLE
Rework to work as a cargo runner

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,13 @@ publish = false
 
 [dependencies]
 regex = "1.4.5"
+structopt = { version = "0.3", default-features = false }
+anyhow = "1.0"
 solana-bpf-loader-program = { git = "https://github.com/solana-labs/solana", version = "=1.9.0" }
 solana-logger = { git = "https://github.com/solana-labs/solana", version = "=1.9.0" }
 solana-program-runtime = { git = "https://github.com/solana-labs/solana", version = "=1.9.0" }
 solana-sdk = { git = "https://github.com/solana-labs/solana", version = "=1.9.0" }
-solana_rbpf = "=0.2.14"
+solana_rbpf = "=0.2.15"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,194 +1,107 @@
+use anyhow::{anyhow, Context};
 use regex::Regex;
+use std::{
+    cell::RefCell,
+    env,
+    ffi::OsStr,
+    fs,
+    io::{self, Write},
+    path::{Path, PathBuf},
+    process::{exit, Command, Stdio},
+    rc::Rc,
+    sync::Arc,
+    time::Instant,
+};
+use structopt::StructOpt;
+
 use solana_bpf_loader_program::{
     create_vm, serialization::serialize_parameters, syscalls::register_syscalls, BpfError,
     ThisInstructionMeter,
 };
-use solana_program_runtime::invoke_context::{
-    prepare_mock_invoke_context, InvokeContext, ThisInvokeContext,
+use solana_program_runtime::{
+    instruction_processor::Executors,
+    invoke_context::{
+        prepare_mock_invoke_context, InvokeContext, ThisComputeMeter, ThisInvokeContext,
+    },
+    log_collector::LogCollector,
 };
 use solana_rbpf::vm::{Config, Executable};
-use solana_sdk::{account::AccountSharedData, bpf_loader, entrypoint::SUCCESS, pubkey::Pubkey};
-use std::{
-    env,
-    ffi::OsStr,
-    fs::File,
-    io::Read,
-    path::{Path, PathBuf},
-    process::{exit, Command, Stdio},
-    time::Instant,
+use solana_sdk::{
+    account::AccountSharedData, bpf_loader, compute_budget::ComputeBudget, entrypoint::SUCCESS,
+    feature_set::FeatureSet, hash::Hash, pubkey::Pubkey, rent::Rent,
 };
 
-/**
- * Start a new process running the program and capturing its output.
- */
-fn spawn<I, S>(program: &Path, args: I) -> (String, String)
+// Start a new process running the program and capturing its output.
+fn spawn<I, S>(program: &Path, args: I) -> Result<(String, String), anyhow::Error>
 where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,
 {
-    let args = args.into_iter().collect::<Vec<_>>();
-    print!("Running on host: {}", program.display());
-    for arg in args.iter() {
-        print!(" {}", arg.as_ref().to_str().unwrap_or("?"));
-    }
-    println!();
-
     let child = Command::new(program)
-        .args(&args)
+        .args(args)
         .stderr(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()
-        .unwrap_or_else(|err| {
-            eprintln!("Failed to execute {}: {}", program.display(), err);
-            exit(1);
-        });
+        .with_context(|| format!("Failed to execute {}", program.display()))?;
 
     let output = child.wait_with_output().expect("failed to wait on child");
-    (
-        output
-            .stdout
-            .as_slice()
-            .iter()
-            .map(|&c| c as char)
-            .collect::<String>(),
-        output
-            .stderr
-            .as_slice()
-            .iter()
-            .map(|&c| c as char)
-            .collect::<String>(),
-    )
-}
-
-/**
- * Run cargo test to build the test binaries and collect the list of the test modules to run.
- */
-fn run_cargo_test<I, S>(args: I) -> String
-where
-    I: IntoIterator<Item = S>,
-    S: AsRef<OsStr>,
-{
-    let cargo = PathBuf::from("cargo");
-    let mut cargo_args = vec!["+bpf", "test", "-v", "--target", "bpfel-unknown-unknown"];
-    let args = args.into_iter().collect::<Vec<_>>();
-    for arg in args.iter() {
-        cargo_args.push(arg.as_ref().to_str().unwrap_or(""));
-    }
-    spawn(&cargo, &cargo_args).1
-}
-
-fn cargo_test_failed(cargo_output: &String) -> bool {
-    let expected = Regex::new(r"error: test failed, to rerun pass '.+'").unwrap();
-    if !expected.is_match(cargo_output) {
-        eprintln!("{}", cargo_output);
-        return true;
-    }
-    false
-}
-
-/**
- * Extract the list of binary modules built by cargo test from the command's output.
- */
-fn extract_tests_list(output: &String) -> Vec<String> {
-    let rust_re =
-        Regex::new(r"^\s*Running `[^ ]*rustc .*--target bpfel-unknown-unknown.+").unwrap();
-    let odir_re = Regex::new(r"^.+--out-dir ([^ ]+).+").unwrap();
-    let name_re = Regex::new(r"^.+--crate-name ([^ ]+).+-C extra-filename=([^ ]+).+").unwrap();
-    let mut result: Vec<String> = Vec::new();
-    let lines = output.lines().collect::<Vec<_>>();
-    for line in lines {
-        let line = line.trim_end();
-        if rust_re.is_match(line) {
-            if odir_re.is_match(line) {
-                let captures = odir_re.captures(line).unwrap();
-                let base = captures[1].to_string();
-                if name_re.is_match(line) {
-                    let captures = name_re.captures(line).unwrap();
-                    result.push(format!(
-                        "{}/{}{}.so",
-                        base,
-                        captures[1].to_string(),
-                        captures[2].to_string()
-                    ));
-                }
-            }
-        }
-    }
-    result
+    Ok((
+        String::from_utf8(output.stdout).context("process stdout is not valid utf8")?,
+        String::from_utf8(output.stderr).context("process stderr is not valid utf8")?,
+    ))
 }
 
 fn extract_sections_list(output: &String) -> Vec<String> {
     let head_re = Regex::new(r"^ +\[[ 0-9]+\] (.bss[^ ]*) .*").unwrap();
+
     let mut result: Vec<String> = Vec::new();
-    let lines = output.lines().collect::<Vec<_>>();
-    for line in lines {
+    for line in output.lines() {
         let line = line.trim_end();
-        if head_re.is_match(line) {
-            let captures = head_re.captures(line).unwrap();
-            result.push(format!("{}", captures[1].to_string()));
+        if let Some(captures) = head_re.captures(line) {
+            result.push(captures[1].to_string());
         }
     }
+
     result
 }
 
-fn remove_bss_sections(module: &String) {
-    let home_dir = PathBuf::from(env::var("HOME").unwrap_or_else(|err| {
-        eprintln!("Can't get home directory path: {}", err);
-        exit(1);
-    }));
-    let llvm_path = home_dir
+fn llvm_home() -> Result<PathBuf, anyhow::Error> {
+    if let Ok(home) = env::var("LLVM_HOME") {
+        return Ok(home.into());
+    }
+
+    let home_dir = PathBuf::from(env::var("HOME").context("Can't get home directory path")?);
+    Ok(home_dir
         .join(".cache")
         .join("solana")
         .join("v1.19")
         .join("bpf-tools")
-        .join("llvm")
-        .join("bin");
+        .join("llvm"))
+}
+
+fn remove_bss_sections(module: &Path) -> Result<(), anyhow::Error> {
+    let module = module.to_string_lossy();
+    let llvm_path = llvm_home()?.join("bin");
     let readelf = llvm_path.join("llvm-readelf");
     let mut readelf_args = vec!["--section-headers"];
-    readelf_args.push(module);
-    let output = spawn(&readelf, &readelf_args).0;
+    readelf_args.push(&module);
+
+    let output = spawn(&readelf, &readelf_args)?.0;
     let sections = extract_sections_list(&output);
+
     for bss in sections {
         let objcopy = llvm_path.join("llvm-objcopy");
         let mut objcopy_args = vec!["--remove-section"];
         objcopy_args.push(&bss);
-        objcopy_args.push(module);
-        spawn(&objcopy, &objcopy_args);
+        objcopy_args.push(&module);
+        spawn(&objcopy, &objcopy_args)?;
     }
+
+    Ok(())
 }
 
-fn is_executable(module: &String) -> bool {
-    let home_dir = PathBuf::from(env::var("HOME").unwrap_or_else(|err| {
-        eprintln!("Can't get home directory path: {}", err);
-        exit(1);
-    }));
-    let llvm_path = home_dir
-        .join(".cache")
-        .join("solana")
-        .join("v1.19")
-        .join("bpf-tools")
-        .join("llvm")
-        .join("bin");
-    let readelf = llvm_path.join("llvm-readelf");
-    let mut readelf_args = vec!["--section-headers"];
-    readelf_args.push(module);
-    let output = spawn(&readelf, &readelf_args).0;
-    let head_re = Regex::new(r"^ +\[[ 0-9]+\] (.text[^ ]*) .*").unwrap();
-    let lines = output.lines().collect::<Vec<_>>();
-    for line in lines {
-        let line = line.trim_end();
-        if head_re.is_match(line) {
-            return true;
-        }
-    }
-    false
-}
-
-/**
- * Execute the test binary modules in RBPF.
- */
-fn run_tests(tests: &Vec<String>) -> bool {
-    let mut failed = false;
+// Execute the given test file in RBPF.
+fn run_tests(path: &Path) -> Result<(), anyhow::Error> {
     let config = Config {
         max_call_depth: 100,
         enable_instruction_tracing: false,
@@ -209,23 +122,38 @@ fn run_tests(tests: &Vec<String>) -> bool {
             AccountSharedData::new_ref(0, 0, &loader_id),
         ),
     ];
-    let instruction_data = vec![];
-    for program in tests {
-        eprintln!("Considering {}", program);
-        let path = PathBuf::from(&program);
-        if !path.exists() || !is_executable(&program) {
-            eprintln!("  Skipping...");
-            continue;
-        }
-        remove_bss_sections(&program);
-        let mut file = File::open(path).unwrap();
-        let mut data = vec![];
-        file.read_to_end(&mut data).unwrap();
-        // Make new context for every test module, otherwise log messages from previous runs accumulate.
-        // DO NOT move outside the loop.
-        let program_indices = [0, 1];
-        let preparation = prepare_mock_invoke_context(&program_indices, &[], &keyed_accounts);
-        let mut invoke_context = ThisInvokeContext::new_mock(&preparation.accounts, &[]);
+    if !path.exists() {
+        return Err(anyhow!(
+            "No such file or directory: {}",
+            path.to_string_lossy()
+        ));
+    }
+
+    remove_bss_sections(path)?;
+    let data = fs::read(path)?;
+
+    let program_indices = [0, 1];
+    let preparation = prepare_mock_invoke_context(&program_indices, &[], &keyed_accounts);
+    let logs = Rc::new(LogCollector::default());
+    let result = {
+        let mut invoke_context = ThisInvokeContext::new(
+            Rent::default(),
+            &preparation.accounts,
+            &[],
+            &[],
+            Some(Rc::clone(&logs)),
+            ComputeBudget {
+                heap_size: Some(50 * 1024 * 1024),
+                ..ComputeBudget::default()
+            },
+            ThisComputeMeter::new_ref(std::i64::MAX as u64),
+            Rc::new(RefCell::new(Executors::default())),
+            None,
+            Arc::new(FeatureSet::all_enabled()),
+            Hash::default(),
+            0,
+        );
+
         invoke_context
             .push(
                 &preparation.message,
@@ -234,7 +162,9 @@ fn run_tests(tests: &Vec<String>) -> bool {
                 Some(&preparation.account_indices),
             )
             .unwrap();
+
         let keyed_accounts = invoke_context.get_keyed_accounts().unwrap();
+        let instruction_data = vec![];
         let (mut parameter_bytes, account_lengths) = serialize_parameters(
             keyed_accounts[0].unsigned_key(),
             keyed_accounts[1].unsigned_key(),
@@ -267,60 +197,66 @@ fn run_tests(tests: &Vec<String>) -> bool {
         let instruction_count = vm.get_total_instruction_count();
         println!(
             "Executed {} {} instructions in {:.2}s.",
-            program,
+            path.to_string_lossy(),
             instruction_count,
             start_time.elapsed().as_secs_f64()
         );
-        match result {
-            Err(e) => {
-                println!("FAILURE {}\n", e);
-                failed = true;
-                // FIX: commented-out traces
-                #[cfg(target_arch = "no_real")]
-                if false {
-                    let trace = File::create("trace.out").unwrap();
-                    let mut trace = BufWriter::new(trace);
-                    let analysis = solana_rbpf::static_analysis::Analysis::from_executable(
-                        executable.as_ref(),
-                    );
-                    vm.get_tracer().write(&mut trace, &analysis).unwrap();
-                }
-            }
-            Ok(v) => {
-                if v == SUCCESS {
-                    println!("SUCCESS\n");
-                } else {
-                    println!("Exit code {}\n", v);
-                }
-            }
-        };
+
+        result
+    };
+
+    if let Ok(logs) = Rc::try_unwrap(logs) {
+        for message in Vec::from(logs) {
+            let _ = io::stdout().write_all(message.replace("Program log: ", "").as_bytes());
+        }
     }
-    failed
+
+    match result {
+        Ok(exit_code) => {
+            if exit_code == SUCCESS {
+                Ok(())
+            } else {
+                Err(anyhow!("exit code: {}", exit_code))
+            }
+        }
+        Err(e) => {
+            // if false {
+            //     let trace = File::create("trace.out").unwrap();
+            //     let mut trace = BufWriter::new(trace);
+            //     let analysis =
+            //         solana_rbpf::static_analysis::Analysis::from_executable(executable.as_ref());
+            //     vm.get_tracer().write(&mut trace, &analysis).unwrap();
+            // }
+            Err(e.into())
+        }
+    }
+}
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "cargo-run-bpf-tests",
+    about = "Test runner for the bpfel-unknown-unknown target"
+)]
+struct Opt {
+    #[allow(dead_code)]
+    #[structopt(long, hidden = true)]
+    quiet: bool,
+    #[structopt(parse(from_os_str))]
+    file: PathBuf,
 }
 
 fn main() {
     solana_logger::setup();
+
     let mut args = env::args().collect::<Vec<_>>();
-    if let Some(arg1) = args.get(1) {
-        if arg1 == "run-bpf-tests" {
-            args.remove(1);
-        }
+    if let Some("run-bpf-tests") = args.get(1).map(|a| a.as_str()) {
+        // we're being invoked as `cargo run-bpf-tests`
+        args.remove(1);
     }
-    if let Some(_) = args.get(0) {
-        args.remove(0);
-    }
-    let cargo_output = run_cargo_test(&args);
-    println!("cargo test output:\n{}", cargo_output);
-    if cargo_test_failed(&cargo_output) {
-        exit(1);
-    }
-    let tests_list = extract_tests_list(&cargo_output);
-    println!("Found the following tests");
-    for test in &tests_list {
-        println!("  {}", test);
-    }
-    let failed = run_tests(&tests_list);
-    if failed {
+
+    let opt = Opt::from_iter(&args);
+    if let Err(e) = run_tests(&opt.file.with_extension("so")) {
+        eprintln!("error: {:#}", e);
         exit(1);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,12 +3,11 @@ use solana_bpf_loader_program::{
     create_vm, serialization::serialize_parameters, syscalls::register_syscalls, BpfError,
     ThisInstructionMeter,
 };
-use solana_program_runtime::invoke_context::{prepare_mock_invoke_context, ThisInvokeContext};
-use solana_rbpf::vm::{Config, Executable};
-use solana_sdk::{
-    account::AccountSharedData, bpf_loader, entrypoint::SUCCESS,
-    process_instruction::InvokeContext, pubkey::Pubkey,
+use solana_program_runtime::invoke_context::{
+    prepare_mock_invoke_context, InvokeContext, ThisInvokeContext,
 };
+use solana_rbpf::vm::{Config, Executable};
+use solana_sdk::{account::AccountSharedData, bpf_loader, entrypoint::SUCCESS, pubkey::Pubkey};
 use std::{
     env,
     ffi::OsStr,


### PR DESCRIPTION
cargo-run-bpf-tests can now be used with `cargo test` directly, eg:

```
CARGO_TARGET_BPFEL_UNKNOWN_UNKNOWN_RUNNER="cargo run-bpf-tests" cargo test --target=bpfel-unknown-unknown
  Compiling bpf-tests v0.1.0 (/Users/alessandro/src/solana/bpf-tests)
    Finished test [unoptimized + debuginfo] target(s) in 0.22s
      Running unittests (target/bpfel-unknown-unknown/debug/deps/bpf_tests-c53db7f8ceb7e780)

running 3 tests
test foo::tests::test_bar ... ok
test tests::test_that ... ok
test tests::test_this ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

As an alternative to setting `CARGO_TARGET_BPFEL_UNKNOWN_UNKNOWN_RUNNER`, the
following can be put in `.cargo/config.toml`:

```
[target.bpfel-unknown-unknown]
runner = "cargo run-bpf-tests"
```